### PR TITLE
fail mkcert install on 404 instead of copying text

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -38,7 +38,11 @@ install_tool() {
   download_path="$tmp_download_dir/"$(get_filename "$version" "$platform" "$binary_name")
 
   echo "Downloading [${binary_name}] from ${download_url} to ${download_path}"
-  curl -Lo "$download_path" "$download_url"
+  if ! curl -fLo "$download_path" "$download_url"; then
+    echo "Error: Failed to download from ${download_url}"
+    echo "The binary might not exist for your platform (${platform})"
+    exit 1
+  fi
 
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"


### PR DESCRIPTION
## Problem
When installing mkcert on M1/M2 Macs (arm64), the asdf install script was silently failing by copying a "Not Found" error page as the binary. This happened because mkcert v1.4.3 doesn't have a darwin-arm64 build available.

## Fix
Added `-f` flag to curl which makes it fail on HTTP errors (like 404) instead of downloading the error page. Added error messaging to help users understand why the installation failed.

Before:
```bash
➜ cat ~/.asdf/installs/mkcert/1.4.3/bin/mkcert
Not Found%
```

After:
```bash
Error: Failed to download from https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-darwin-arm64
The binary might not exist for your platform (darwin-arm64)
```